### PR TITLE
Fix/error handling and bugs

### DIFF
--- a/django_weather_app/settings.py
+++ b/django_weather_app/settings.py
@@ -149,3 +149,23 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # GeoIP settings
 GEOIP_PATH = BASE_DIR / "geoip"
+
+# Logging
+# Console logging for the weather app. Debug-level details are shown only when
+# DEBUG is enabled; otherwise warnings and errors are surfaced.
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'weather': {
+            'handlers': ['console'],
+            'level': 'DEBUG' if DEBUG else 'WARNING',
+            'propagate': False,
+        },
+    },
+}

--- a/weather/utils/geo.py
+++ b/weather/utils/geo.py
@@ -1,10 +1,13 @@
 # weather/utils/geo.py
 
+import logging
 from functools import lru_cache
 import os
 from ipware import get_client_ip  # type: ignore
 from django.contrib.gis.geoip2 import GeoIP2
 from django_weather_app import settings
+
+logger = logging.getLogger(__name__)
 
 @lru_cache
 def _geoip():
@@ -19,8 +22,7 @@ def get_client_ip_address(request):
     """
 
     ip, is_routable = get_client_ip(request)
-    if settings.DEBUG:
-        print(f"Client IP: {ip}, Is routable: {is_routable}")  # Debug
+    logger.debug("Client IP: %s, Is routable: %s", ip, is_routable)
     return ip if ip and is_routable else None
 
 def get_city_by_ip(ip: str | None) -> str | None:
@@ -30,15 +32,12 @@ def get_city_by_ip(ip: str | None) -> str | None:
     try:
         geoip_instance = _geoip()
         result = geoip_instance.city(ip)
-        if settings.DEBUG:
-            print(f"Full GeoIP result: {result}")  # Debug - show full result
+        logger.debug("Full GeoIP result: %s", result)
         city = result.get("city")
-        if settings.DEBUG:
-            print(f"GeoIP city lookup result: {city}")  # Debug
+        logger.debug("GeoIP city lookup result: %s", city)
         return city
-    except Exception as e:
-        if settings.DEBUG:
-            print(f"GeoIP error for IP {ip}: {e}")  # Debug - show IP
+    except Exception:
+        logger.warning("GeoIP lookup failed for IP %s", ip, exc_info=True)
         return None
 
 def index(request):
@@ -47,28 +46,23 @@ def index(request):
     In DEBUG mode on localhost, use test IP for GeoIP lookup when real IP is not available.
     """
     ip = get_client_ip_address(request)
-    if settings.DEBUG:
-        print(f"Client IP address: {ip}")  # Debug
+    logger.debug("Client IP address: %s", ip)
 
-        # In local development, use test IP if real IP is not available
+    # In local development, use test IP if real IP is not available
     if settings.DEBUG and not ip:
         test_ip = os.getenv('DEV_TEST_IP')
-        if settings.DEBUG:
-            print(f"DEBUG mode: using test IP {test_ip} for GeoIP lookup")  # Debug
+        logger.debug("DEBUG mode: using test IP %s for GeoIP lookup", test_ip)
         city = get_city_by_ip(test_ip)
         # If GeoIP doesn't return a city, use default fallback
         if not city:
             city = "Helsinki"
-            if settings.DEBUG:
-                print("DEBUG mode: GeoIP didn't return city, using fallback 'Helsinki'")
+            logger.debug("DEBUG mode: GeoIP didn't return city, using fallback 'Helsinki'")
     else:
         city = get_city_by_ip(ip)
         # If no city found in production, use Helsinki fallback
         if not city:
             city = "Helsinki"
-            if settings.DEBUG:
-                print("No city found for IP, using fallback city: Helsinki")
+            logger.debug("No city found for IP, using fallback city: Helsinki")
 
-    if settings.DEBUG:
-        print(f"City determined from request: {city}")  # Debug
+    logger.debug("City determined from request: %s", city)
     return city

--- a/weather/utils/get_current_uv_index.py
+++ b/weather/utils/get_current_uv_index.py
@@ -1,9 +1,15 @@
+import logging
 import requests
+
+logger = logging.getLogger(__name__)
 
 def get_current_uv_index(openweathermap_api_key: str, lat: float, lon: float):
     try:
         url = f'http://api.openweathermap.org/data/2.5/uvi?appid={openweathermap_api_key}&lat={lat}&lon={lon}'
         response = requests.get(url).json()
-        return response['value']  # Returns the UV index value from the response
-    except Exception as e:
+        if isinstance(response, dict):
+            return response.get('value', 'N/A')  # Returns the UV index value from the response
+        return "N/A"
+    except Exception:
+        logger.exception("Error fetching current UV index for lat=%s lon=%s", lat, lon)
         return "N/A"

--- a/weather/utils/get_uv_forecast.py
+++ b/weather/utils/get_uv_forecast.py
@@ -1,5 +1,17 @@
+import logging
 from requests import get
 from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+def _default_uv_forecast():
+    """Return moderate default UV values for the next 3 days."""
+    forecast = []
+    for i in range(3):
+        date = datetime.now() + timedelta(days=i)
+        date_str = date.strftime("%Y-%m-%d")
+        forecast.append({'date': date_str, 'uv': 5})  # Default moderate UV
+    return forecast
 
 def get_uv_forecast(location: str, openweathermap_api_key: str):
     """
@@ -10,11 +22,15 @@ def get_uv_forecast(location: str, openweathermap_api_key: str):
         geo_url = f'http://api.openweathermap.org/geo/1.0/direct?q={location}&limit=1&appid={openweathermap_api_key}'
         geo_response = get(geo_url).json()
 
-        if not geo_response:
+        if not isinstance(geo_response, list) or not geo_response:
             return None
 
-        lat = geo_response[0]['lat']
-        lon = geo_response[0]['lon']
+        first = geo_response[0]
+        if 'lat' not in first or 'lon' not in first:
+            return None
+
+        lat = first['lat']
+        lon = first['lon']
 
         forecast = []
 
@@ -29,7 +45,7 @@ def get_uv_forecast(location: str, openweathermap_api_key: str):
 
             # For forecast days beyond today, use a reasonable estimate
             # (OpenWeatherMap's UV API primarily gives current UV)
-            uv_value = uv_response.get('value', 5)  # Default to moderate UV
+            uv_value = uv_response.get('value', 5) if isinstance(uv_response, dict) else 5  # Default to moderate UV
 
             # Adjust UV based on day (simple heuristic)
             if i == 0:  # Today
@@ -46,11 +62,7 @@ def get_uv_forecast(location: str, openweathermap_api_key: str):
 
         return forecast
 
-    except Exception as e:
+    except Exception:
+        logger.exception("Error fetching UV forecast for location=%s", location)
         # Return default moderate UV values if API fails
-        forecast = []
-        for i in range(3):
-            date = datetime.now() + timedelta(days=i)
-            date_str = date.strftime("%Y-%m-%d")
-            forecast.append({'date': date_str, 'uv': 5})  # Default moderate UV
-        return forecast
+        return _default_uv_forecast()

--- a/weather/utils/get_weather_forecast.py
+++ b/weather/utils/get_weather_forecast.py
@@ -1,8 +1,11 @@
+import logging
 from requests import get
 from datetime import datetime
 import pytz
 from django.core.cache import cache
 from weather.utils.get_uv_forecast import get_uv_forecast
+
+logger = logging.getLogger(__name__)
 
 def get_weather_forecast(openweathermap_api_key: str, city: str):
 
@@ -52,6 +55,6 @@ def get_weather_forecast(openweathermap_api_key: str, city: str):
 
         return forecasts_by_day
 
-    except Exception as e:
-        print(f"Error fetching weather forecast: {e}")
+    except Exception:
+        logger.exception("Error fetching weather forecast for city=%s", city)
         return None

--- a/weather/utils/get_weather_with_uv.py
+++ b/weather/utils/get_weather_with_uv.py
@@ -1,8 +1,11 @@
+import logging
 from requests import get
 from datetime import datetime
 import pytz
 from django.core.cache import cache
 from weather.utils.get_current_uv_index import get_current_uv_index
+
+logger = logging.getLogger(__name__)
 
 def get_weather_with_uv(openweathermap_api_key: str, city: str):
     # Try to fetch from the cache
@@ -54,5 +57,6 @@ def get_weather_with_uv(openweathermap_api_key: str, city: str):
 
         return weather
 
-    except Exception as e:
+    except Exception:
+        logger.exception("Error fetching weather for city=%s", city)
         return None

--- a/weather/views.py
+++ b/weather/views.py
@@ -1,7 +1,7 @@
 # weather/views.py
 
+import logging
 from django.shortcuts import render
-from django.http import HttpResponse
 from dotenv import load_dotenv
 import os
 
@@ -9,9 +9,24 @@ from weather.utils.get_weather_with_uv import get_weather_with_uv
 from weather.utils.get_weather_forecast import get_weather_forecast
 from weather.utils import geo
 
+logger = logging.getLogger(__name__)
+
 # Load environment variables from .env file
 load_dotenv()
 openweathermap_api_key = os.getenv('OPENWEATHERMAP_API_KEY')
+
+# Maximum accepted length for a city name from user input.
+MAX_CITY_LENGTH = 100
+
+def is_valid_city(city: str) -> bool:
+    """Return True if the city string is safe to use in an API lookup.
+
+    Guards against empty input, overly long strings and control characters.
+    Invalid input is treated the same as a failed lookup by the views.
+    """
+    if not city or len(city) > MAX_CITY_LENGTH:
+        return False
+    return not any(ord(char) < 32 for char in city)
 
 def index(request):
     """Front page where the user can search for weather or forecast."""
@@ -26,7 +41,9 @@ def index(request):
 
     if request.method == "GET" and 'city' in request.GET:
         option = request.GET.get('option')
-        if option == "weather":
+        if not is_valid_city(city):
+            error_message = 'Sorry, that does not look like a valid city name.'
+        elif option == "weather":
             weather = get_weather_with_uv(openweathermap_api_key, city)  # type: ignore
             if weather:
                 return render(request, 'current_weather.html', {'weather': weather, 'city': city})
@@ -43,13 +60,18 @@ def current_weather_view(request):
     """Display fetched weather for the city determined by GeoIP (with Helsinki fallback in DEBUG)."""
     city = geo.index(request)
 
-    if not city:
-        return render(request, '404.html', {'error_message': 'Could not determine your city.'})
+    if not is_valid_city(city):
+        return render(request, '404.html', {'error_message': 'Could not determine your city.'}, status=404)
 
     weather = get_weather_with_uv(openweathermap_api_key, city)  # type: ignore
     if weather:
         return render(request, 'current_weather.html', {'weather': weather, 'city': city})
-    return HttpResponse(f'Sorry, the weather data for {city.capitalize()} could not be retrieved.')
+    return render(
+        request,
+        '404.html',
+        {'error_message': f'Sorry, the weather data for {city.capitalize()} could not be retrieved.'},
+        status=404,
+    )
 
 def custom_404(request, exception=None):
     """Handle 404 errors with custom page."""


### PR DESCRIPTION
## Summary

Bug and error-handling fixes for the weather app. No UI, CSS, accessibility, or template-markup changes — the only template-related change is that the `/weather/` failure path now renders the existing styled 404 page instead of raw text. Focuses on crash-safety against malformed API responses, consistent error responses, server-side input validation, and replacing `print()`/silent exception swallows with proper logging.

## What changed

**Logging** (`feat: add structured logging for weather utils`)
- Added a minimal console `LOGGING` config for the `weather` logger in `django_weather_app/settings.py` — DEBUG level when `DEBUG=True`, otherwise WARNING.
- Replaced debug-guarded `print()` calls with `logger.debug()` in `weather/utils/geo.py`; GeoIP lookup failures are now logged.
- Logged exceptions in `weather/utils/get_weather_with_uv.py` (was a silent `return None`) and `weather/utils/get_weather_forecast.py` (was `print()`).

**Crash-safety** (`fix: guard against malformed api responses in uv utils`)
- `weather/utils/get_current_uv_index.py`: validate dict response and use `response.get('value', 'N/A')` instead of `response['value']`.
- `weather/utils/get_uv_forecast.py`: verify the geo response is a non-empty list with `lat`/`lon` before indexing; extracted the default-forecast fallback into a helper to remove duplication.
- Return contracts (`"N/A"` / default forecast) unchanged.

**View validation & error responses** (`fix: validate city input and return styled error responses`)
- Added `is_valid_city()` guard (non-empty, ≤100 chars, no control characters), used in both views; invalid input is treated as a failed lookup — styled error, no API call, no crash.
- `current_weather_view` now renders the existing `404.html` with `status=404` on failure instead of an unstyled `HttpResponse` at status 200, matching the index page's error handling.

## How to test

1. `python manage.py check` → no issues.
2. Run with a valid `OPENWEATHERMAP_API_KEY` and search a valid city → current weather and 3-day forecast render unchanged.
3. Search a clearly invalid city (e.g. `asdkjhasd`) or an over-long `?city=` value → styled error on the index page, HTTP 200, no traceback.
4. Trigger the `/weather/` failure path (e.g. wrong API key) → styled `404.html` with status 404, not raw text.
5. Hit an unknown URL → existing custom 404 still works.

Verified via Django test client: invalid/over-long city → styled error at 200; `/weather/` failure → styled 404 at status 404; index weather failure → styled error at 200; happy path renders `current_weather.html` unchanged; unknown URL → 404.

## Notes

- Out of scope (per request): accessibility-only template changes, unit tests, linting config, and any visual/CSS change.
- `git diff` confirms only 7 Python files changed; `staticfiles/` untouched.
- Happy-path context shapes are identical, so `current_weather.html` and `forecast.html` render exactly as before.
