### PR TITLE
Fix/UI accessibility polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ A Django-based web application that provides real-time weather data and a 3-day 
 
 - **Backend**: Django (Python) with Gunicorn
 - **Frontend**: HTML, CSS (with responsive design)
-- **Web Server**: Nginx (reverse proxy and static files)
+- **Static Files**: WhiteNoise (compressed static file serving from the app)
+- **Web Server**: Nginx (reverse proxy)
 - **APIs**: [OpenWeatherMap API](https://openweathermap.org/api)
 - **Geolocation**: GeoIP2 database for IP-based city detection
 - **Containerization**: Docker & Docker Compose
@@ -75,9 +76,11 @@ A Django-based web application that provides real-time weather data and a 3-day 
    - Follow instructions in `geoip/README.md` to download the GeoLite2 database
    - This is required for IP-based geolocation functionality
 
-4. Start development server:
+4. Run migrations and start the development server:
 
    ```bash
+   python manage.py migrate
+   python manage.py collectstatic
    python manage.py runserver
    ```
 
@@ -88,45 +91,6 @@ A Django-based web application that provides real-time weather data and a 3-day 
 - Make changes to HTML/CSS/Python files
 - Refresh your browser (Cmd+R / Ctrl+R) to see changes
 - Django automatically restarts when Python files change
-
-1. Clone and navigate:
-
-   ```bash
-   git clone https://github.com/yumeangelica/django-weather-app.git
-   cd django-weather-app
-   ```
-
-2. Install dependencies:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-3. Get your API key:
-
-   - Sign up at [OpenWeatherMap](https://home.openweathermap.org/users/sign_up)
-   - Create a `.env` file:
-     ```
-     OPENWEATHERMAP_API_KEY=your_openweathermap_api_key
-     SECRET_KEY=your_django_secret_key
-     DEBUG=True
-     ALLOWED_HOSTS=localhost,127.0.0.1
-     DEV_TEST_IP=your_ip_for_testing  # Optional: for local geolocation testing
-     ```
-
-4. **Download GeoIP database**:
-
-   - Follow instructions in `geoip/README.md` to download the GeoLite2 database
-
-5. Run migrations and start server:
-
-   ```bash
-   python manage.py migrate
-   python manage.py collectstatic
-   python manage.py runserver
-   ```
-
-6. Visit: http://127.0.0.1:8000
 
 ## Azure Deployment
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -18,7 +18,7 @@
   --color-button-hover: rgb(130, 62, 100);
 
   /* Extended palette */
-  --color-text-light: rgb(100, 100, 100);
+  --color-text-light: rgb(85, 85, 85);
   --color-border: rgb(234, 210, 226);
   --color-input-border: rgb(220, 195, 212);
   --color-error: rgb(200, 50, 50);
@@ -220,14 +220,23 @@ input[type="search"]:focus {
   gap: 0.75rem;
   margin-bottom: 2rem;
   text-align: left;
+  /* reset fieldset defaults so the converted markup looks unchanged */
+  border: 0;
+  padding: 0;
+  min-width: 0;
 }
 
-.radio-group p {
+.radio-group p,
+.radio-group legend {
   font-weight: 600;
   font-size: 1.05rem;
   margin-bottom: 0.5rem;
   text-align: center;
   color: var(--color-primary-dark);
+  /* legend defaults: span full width and drop its inline padding */
+  width: 100%;
+  padding: 0;
+  float: none;
 }
 
 .radio-option {
@@ -281,6 +290,9 @@ input[type="search"]:focus {
 
 /* ───────────── Error Messages ───────────── */
 .error-message {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   background: var(--color-error-bg);
   color: var(--color-error);
   padding: 1rem 1.25rem;
@@ -289,6 +301,41 @@ input[type="search"]:focus {
   font-weight: 500;
   border-left: 4px solid var(--color-error);
   font-size: 0.925rem;
+}
+
+.error-message-text {
+  flex: 1;
+}
+
+.error-close {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--color-error);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  box-shadow: none;
+  transition: background var(--transition-duration) var(--ease-out);
+}
+
+.error-close:hover {
+  background: rgba(200, 50, 50, 0.1);
+  transform: none;
+  box-shadow: none;
+}
+
+.error-close:focus-visible {
+  outline: 2px solid var(--color-error);
+  outline-offset: 2px;
+  box-shadow: none;
 }
 
 /* ───────────── Temperature Hero ───────────── */
@@ -494,6 +541,14 @@ input[type="search"]:focus {
   z-index: 10;
   min-width: 110px;
   font-size: 0.8rem;
+}
+
+/* Row-header cells use <th scope="row"> for a11y; keep the body-row look
+   (override the .forecast-table th nav-bg background and uppercasing). */
+.forecast-table tbody th.sticky-left {
+  background: var(--color-card-bg);
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 /* ───────────── Forecast Cards (Mobile) ───────────── */
@@ -754,6 +809,64 @@ input[type="search"]:focus {
   .forecast-hours {
     grid-template-columns: repeat(6, 1fr);
   }
+}
+
+/* ───────────── Utilities ───────────── */
+/* Visually hidden but available to assistive tech */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Skip link — hidden until focused via keyboard */
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-120%);
+  z-index: 100;
+  margin: 0.5rem;
+  padding: 0.625rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-primary-dark);
+  background: var(--color-card-bg);
+  border: 1.5px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  box-shadow: var(--shadow-md);
+  transition: transform var(--transition-duration) var(--ease-out);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Moved from inline styles — values unchanged */
+.temp-feels-like {
+  margin-top: 0.75rem;
+  color: var(--color-text-light);
+  font-size: 0.95rem;
+}
+
+.error-page {
+  text-align: center;
+  padding: 3rem 2rem;
+}
+
+.error-page-message {
+  color: var(--color-text-light);
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
 }
 
 /* ───────────── Accessibility ───────────── */

--- a/templates/404.html
+++ b/templates/404.html
@@ -14,20 +14,21 @@
 </head>
 
 <body>
+  <a href="#main" class="skip-link">Skip to content</a>
   <div class="container">
     <header class="header">
       <h1>404 — Not Found</h1>
       <p>The page you're looking for doesn't exist</p>
     </header>
 
-    <main class="main-content" style="text-align: center; padding: 3rem 2rem;">
+    <main class="main-content error-page" id="main">
       {% if error_message %}
-      <p style="color: var(--color-text-light); font-size: 1.1rem; margin-bottom: 2rem;">
+      <p class="error-page-message">
         {{ error_message }}
       </p>
       {% endif %}
 
-      <a href="/" class="button">← Back to Home</a>
+      <a href="/" class="button"><span aria-hidden="true">←</span> Back to Home</a>
     </main>
 
     {% include "partials/footer.html" %}

--- a/templates/current_weather.html
+++ b/templates/current_weather.html
@@ -14,15 +14,16 @@
 </head>
 
 <body>
+  <a href="#main" class="skip-link">Skip to content</a>
   <div class="container">
     <header class="header">
       <h1>Weather in {{ city|capfirst }}</h1>
       <p class="weather-date">{{ weather.date }}</p>
     </header>
 
-    <main class="main-content">
+    <main class="main-content" id="main">
       <nav class="nav-container nav-center">
-        <a href="/" class="button">← Back to Search</a>
+        <a href="/" class="button"><span aria-hidden="true">←</span> Back to Search</a>
         <a href="/?city={{ city }}&option=forecast" class="button">View 3-Day Forecast</a>
       </nav>
 
@@ -30,7 +31,7 @@
       <div class="temp-main">
         <div class="temp-value">{{ weather.temperature }}°</div>
         <div class="temp-description">{{ weather.description }}</div>
-        <div style="margin-top: 0.75rem; color: var(--color-text-light); font-size: 0.95rem;">
+        <div class="temp-feels-like">
           Feels like {{ weather.feels_like }}°C
         </div>
       </div>

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -14,15 +14,16 @@
 </head>
 
 <body>
+  <a href="#main" class="skip-link">Skip to content</a>
   <div class="container">
     <header class="header">
       <h1>3-Day Forecast</h1>
       <p>{{ city|capfirst }}</p>
     </header>
 
-    <main class="main-content">
+    <main class="main-content" id="main">
       <nav class="nav-container nav-center">
-        <a href="/" class="button">← Back to Search</a>
+        <a href="/" class="button"><span aria-hidden="true">←</span> Back to Search</a>
         <a href="/?city={{ city }}&option=weather" class="button">Current Weather</a>
       </nav>
 
@@ -30,11 +31,12 @@
         <!-- Desktop Table -->
         <div class="forecast-table-wrapper">
           <table class="forecast-table">
+            <caption class="sr-only">3-day hourly forecast for {{ city|capfirst }}</caption>
             <thead>
               <tr>
-                <th class="sticky-left"></th>
+                <th class="sticky-left"><span class="sr-only">Metric</span></th>
                 {% for date, day_data in forecast.items %}
-                <th class="forecast-column-header" colspan="{{ day_data.forecasts|length }}">
+                <th class="forecast-column-header" scope="colgroup" colspan="{{ day_data.forecasts|length }}">
                   {{ day_data.formatted_date }}
                 </th>
                 {% endfor %}
@@ -42,7 +44,7 @@
             </thead>
             <tbody>
               <tr>
-                <td class="sticky-left">Time</td>
+                <th scope="row" class="sticky-left">Time</th>
                 {% for day_data in forecast.values %}
                 {% for forecast in day_data.forecasts %}
                 <td class="forecast-column-cell">{{ forecast.hour }}</td>
@@ -50,7 +52,7 @@
                 {% endfor %}
               </tr>
               <tr>
-                <td class="sticky-left">Temperature</td>
+                <th scope="row" class="sticky-left">Temperature</th>
                 {% for day_data in forecast.values %}
                 {% for forecast in day_data.forecasts %}
                 <td class="forecast-column-cell">{{ forecast.temperature }}°C</td>
@@ -58,7 +60,7 @@
                 {% endfor %}
               </tr>
               <tr>
-                <td class="sticky-left">Weather</td>
+                <th scope="row" class="sticky-left">Weather</th>
                 {% for day_data in forecast.values %}
                 {% for forecast in day_data.forecasts %}
                 <td class="forecast-column-cell">{{ forecast.description }}</td>
@@ -66,7 +68,7 @@
                 {% endfor %}
               </tr>
               <tr>
-                <td class="sticky-left">Humidity</td>
+                <th scope="row" class="sticky-left">Humidity</th>
                 {% for day_data in forecast.values %}
                 {% for forecast in day_data.forecasts %}
                 <td class="forecast-column-cell">{{ forecast.humidity }}%</td>
@@ -74,7 +76,7 @@
                 {% endfor %}
               </tr>
               <tr>
-                <td class="sticky-left">Wind Speed</td>
+                <th scope="row" class="sticky-left">Wind Speed</th>
                 {% for day_data in forecast.values %}
                 {% for forecast in day_data.forecasts %}
                 <td class="forecast-column-cell">{{ forecast.wind_speed }} m/s</td>
@@ -82,7 +84,7 @@
                 {% endfor %}
               </tr>
               <tr>
-                <td class="sticky-left">UV Index</td>
+                <th scope="row" class="sticky-left">UV Index</th>
                 {% for day_data in forecast.values %}
                 {% for forecast in day_data.forecasts %}
                 <td class="forecast-column-cell">{{ forecast.uv_index|default:"N/A" }}</td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,33 +14,26 @@
 </head>
 
 <body>
+  <a href="#main" class="skip-link">Skip to content</a>
   <div class="container">
     <header class="header">
       <h1>Django Weather App</h1>
       <p>Your beautiful weather companion</p>
     </header>
 
-    <main class="main-content">
+    <main class="main-content" id="main">
       {% if error_message %}
       <div class="error-message" role="alert">
-        {{ error_message }}
+        <span class="error-message-text">{{ error_message }}</span>
+        <button type="button" class="error-close" aria-label="Dismiss message">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
-      <script>
-        document.addEventListener('DOMContentLoaded', function () {
-          const errorMsg = document.querySelector('.error-message');
-          if (errorMsg) {
-            setTimeout(() => {
-              errorMsg.style.opacity = '0';
-              errorMsg.style.transition = 'opacity 0.4s ease';
-              setTimeout(() => errorMsg.style.display = 'none', 400);
-            }, 5000);
-          }
-        });
-      </script>
       {% endif %}
 
       <form method="GET" action="{% url 'index' %}" class="search-form">
         <div class="search-box">
+          <label for="city" class="sr-only">City name</label>
           <input
             type="text"
             id="city"
@@ -53,8 +46,8 @@
           >
         </div>
 
-        <div class="radio-group">
-          <p>Choose what you'd like to see:</p>
+        <fieldset class="radio-group">
+          <legend>Choose what you'd like to see:</legend>
 
           <label class="radio-option">
             <input type="radio" id="current_weather" name="option" value="weather" checked>
@@ -71,7 +64,7 @@
               <small>Hourly predictions for the next 3 days</small>
             </span>
           </label>
-        </div>
+        </fieldset>
 
         <button type="submit" class="button">
           Get Weather
@@ -98,6 +91,10 @@
     document.querySelector('input[type="radio"]:checked')
       ?.closest('.radio-option')
       ?.classList.add('checked');
+
+    document.querySelector('.error-close')?.addEventListener('click', function () {
+      this.closest('.error-message')?.remove();
+    });
   </script>
 </body>
 


### PR DESCRIPTION
## Summary

UI and accessibility audit and fixes for the weather app. The app was already
well-built (semantic landmarks, focus-visible states, prefers-contrast and
prefers-reduced-motion support, responsive layout), so these are targeted,
non-breaking improvements. **No styling or colors were changed** — only one
approved subtle contrast nudge to an existing token. Also refreshes the README.

## What changed

### Accessibility (semantics, no visual change)
- **Skip-to-content link** + `id="main"` on all four pages (visible only on keyboard focus).
- **index.html**: visually-hidden `<label for="city">` for the search input (was placeholder-only);
  radio group converted from `<div>`+`<p>` to `<fieldset>`+`<legend>` (CSS keeps the identical look).
- **forecast.html**: table given `<caption class="sr-only">`, `scope="colgroup"` on day headers,
  and row labels changed from `<td>` to `<th scope="row">`. Data cells stay `<td>`.
- Decorative back arrows (`←`) wrapped in `<span aria-hidden="true">`.

### UX
- **Error message**: removed the 5s auto-hide (violated WCAG 2.2.1 and dismissed a `role="alert"`
  before it could be read); replaced with an accessible close button (`×`, `aria-label`). `role="alert"` kept.
- **Contrast**: `--color-text-light` darkened `rgb(100,100,100)` → `rgb(85,85,85)` to meet AA (4.5:1)
  for small labels on card backgrounds. Same neutral grey, no new palette color.

### Cleanup
- Inline styles moved to CSS classes (`.temp-feels-like`, `.error-page`, `.error-page-message`)
  with identical values in current_weather.html and 404.html.

### Docs
- README: removed a duplicated setup section, merged the useful `migrate`/`collectstatic` steps into
  the single Local Development guide, and added WhiteNoise to the tech list (it serves static files,
  not Nginx).

## How to test

1. `python manage.py runserver` (DEBUG mode falls back to Helsinki for geolocation).
2. **index** (`/`): Tab once → skip link appears and jumps to `<main>`; city input is now labeled;
   radios are grouped under a legend.
3. **Error path** (`/?city=%01&option=weather`): error box shows, **does not auto-disappear**, and the
   close button dismisses it; `role="alert"` intact.
4. **Current weather** (`/?city=Helsinki&option=weather`) and **forecast**
   (`/?city=Helsinki&option=forecast`): render identically; in DevTools the forecast table now has
   `<caption class="sr-only">`, `scope="colgroup"`, and `<th scope="row">`.
5. **404** (any bad URL): renders identically, returns HTTP 404.
6. Run axe/Lighthouse on each page — no "form field without label", "table header", or contrast flags
   on the targeted items. Compare desktop/tablet/phone before vs after: layout, spacing, fonts, and
   colors are unchanged (only `--color-text-light` marginally darker).

## Notes

- No dependencies added; no view/business-logic changes.
- Out of scope (left intentionally to avoid layout risk): restructuring the weather grid into a `<dl>`,
  and ARIA restructuring of the mobile forecast cards (they are an alternate view of the canonical table).
